### PR TITLE
Terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Número de argumentos que uma função aceita. Por exemplo, em Python a função
 Estrutura formada por uma função e um ambiente com variáveis necessários para a execução da função, mas não definidas no corpo da função -- chamadas variáveis livres ou não-locais. Uma linguagem só precisa implementar o mecanismo de closure se ela permite a definição de uma função dentro de outra, e permite que a função externa devolva a função interna como resultado. C e Pascal não precisam de closures; Scheme e Python precisam.
 
 #### Environment
+
 - :white_check_mark: ambiente
 
 Em teoria de linguagens de programação, ambiente é uma estrutura de dados que associa identificadores de variáveis a valores. A implementação de uma linguagem com suporte a variáveis precisa ter pelo menos um ambiente global. Linguagens que implementam funções normalmente criam um ambiente local ao executar cada função. Além desses ambientes global e local, linguagens que permitem funções definidas dentro de outras também podem implementar closures. Dicionários e listas associativas são formas comuns de implementar ambientes.
@@ -72,8 +73,6 @@ Pode se referir a expressões matemáticas ou algébricas. Geralmente com o intu
 - :x: Lixeiro
 
 Sub-sistema de ambiente de execução de uma linguagem de programação que faz o descarte automático de estruturas de dados que não podem mais ser acessadas pelo programa do usuário. Smalltalk, Java, Python são linguagens com coletores de lixo integrados ao seu ambiente de execução. Em Go, o coletor de lixo é parte do código gerado pelo compilador ao produzir um executável.
-s-expression
-A sintaxe de expressões da linguagem LISP, formada por parêntesis aninhados, símbolos separados por espaços, e operadores prefixos (e não infixos como na aritmética convencional). A fórmula de Pitágoras pode ser escrita assim em LISP: `(sqrt (+ (* a a) (* b b)))`.
 
 #### Guards
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,18 @@ Número de argumentos que uma função aceita. Por exemplo, em Python a função
 
 #### Closure
 
-- :white_check_mark: Closure
+- :white_check_mark: Clausura
+- :x: Closure
 - :x: Clojure
 - :x: Fechamento
 
 Estrutura formada por uma função e um ambiente com variáveis necessários para a execução da função, mas não definidas no corpo da função -- chamadas variáveis livres ou não-locais. Uma linguagem só precisa implementar o mecanismo de closure se ela permite a definição de uma função dentro de outra, e permite que a função externa devolva a função interna como resultado. C e Pascal não precisam de closures; Scheme e Python precisam.
+
+#### Composable
+
+- :white_check_mark: Componível
+
+Diz-se de funções que se prestam bem à composição, que é a agregação de funções mais simples para criar outras, mais elaboradas.
 
 #### Environment
 
@@ -91,6 +98,14 @@ Sub-sistema de ambiente de execução de uma linguagem de programação que faz 
 - :white_check_mark: Avaliação ociosa
 - :x: Avaliação preguiçosa
 
+#### Monad
+
+- :white_check_mark: Mônada
+
+#### Monoid
+
+- :white_check_mark: Monoide
+
 #### Pattern Matching
 
 - :white_check_mark: Casamento de Padrões
@@ -126,6 +141,4 @@ Declarações funcionam ou como controle do fluxo de controle do programa como p
 
 ### TODO
 
-- monad
-- monoid
 - curse of dimensionality


### PR DESCRIPTION
Primeiro, uma definição estranha ao termo onde se encontrada foi removida.

Em seguida, sugeri alterar a tradução de _closure_ para _clausura_, cf. Wikipédia e [outras ocorrências](https://www.google.com.br/search?q=clausura+programação+função&oq=clausura+programação+função) da palavra em português

Adicionei as traduções de _composable/componível, monad/mônada_ e _monoid/monoide_.